### PR TITLE
Dereference hash for calling 'keys'

### DIFF
--- a/source/lib/Test/DBIC/ExpectedQueries.pm
+++ b/source/lib/Test/DBIC/ExpectedQueries.pm
@@ -423,7 +423,7 @@ sub check_table_operation_counts {
 
     if(scalar keys %$table_test_result) {
         my $message = "";
-        for my $table (sort keys $table_test_result) {
+        for my $table (sort keys %{$table_test_result}) {
             $message .= "* Table: $table\n";
             $message .= join("\n", @{$table_test_result->{$table}});
             $message .= "\nActually executed SQL queries on table '$table':\n";


### PR DESCRIPTION
I got following error when testing.

```
% prove -Ilib -v t/class.t
t/class.t .. keys on reference is experimental at lib/Test/DBIC/ExpectedQueries.pm line 426.
Compilation failed in require at t/class.t line 6.
BEGIN failed--compilation aborted at t/class.t line 6.
Dubious, test returned 2 (wstat 512, 0x200)
No subtests run 

Test Summary Report
-------------------
t/class.t (Wstat: 512 Tests: 0 Failed: 0)
  Non-zero exit status: 2
  Parse errors: No plan found in TAP output
```
